### PR TITLE
feat: re-added search to home page. Searches ONLY docs.

### DIFF
--- a/_includes/custom-hero-search.html
+++ b/_includes/custom-hero-search.html
@@ -1,0 +1,28 @@
+<div class="uk-section section-hero uk-position-relative uk-container uk-container-small" data-uk-scrollspy="cls: uk-animation-slide-bottom-medium; repeat: true">
+  <h1 class="uk-text-center">Search Docs</h1>
+  <div class="hero-search">
+
+      <!-- Html Elements for Search -->
+      <div class="uk-position-relative">
+          <form class="uk-search uk-search-default uk-width-1-1" name="search-hero" onsubmit="return false;">
+              <span class="uk-search-icon-flip" data-uk-search-icon></span>
+              <input id="search-hero" class="uk-search-input uk-box-shadow-large" type="search" placeholder="{{ site.data.translation[site.lang].search_placeholder | default: "Search for answers" }}" autocomplete="off">
+          </form>
+          <ul id="search-hero-results" class="uk-position-absolute uk-width-1-1 uk-list"></ul>
+      </div>
+
+      <script>
+      SimpleJekyllSearch({
+          searchInput: document.getElementById('search-hero'),
+          resultsContainer: document.getElementById('search-hero-results'),
+          noResultsText: '<li class="no-results">{{ site.data.translation[site.lang].search_no_results | default: "No results found" }}</li>',
+          searchResultTemplate: '<li><a href="{url}">{title}</a></li>',
+          json: '/search.json'
+      });
+
+      searchResults("search-hero");
+
+      </script>
+
+  </div>
+</div>

--- a/index.md
+++ b/index.md
@@ -14,7 +14,10 @@ hero:
         This is a place for our tools, results, tutorials, and workshop videos, and a list of activities to come.  Tucked inside are many interesting by-products (decompositions, tensor space compression, search algorithms, random models, and exotic constructions).  Feel free to share these, give us feedback, and to get involved in improvements.
     </p>
 </div>
+
 {% include boxes.html columns="3" title="Browse Topics" subtitle="" %}
+
+{% include custom-hero-search.html %}
 
 {% include featured.html tag="featured" title="Popular Articles" subtitle="Featured articles to get you started fast." %}
 


### PR DESCRIPTION
Close #16 

Added the searchbar to the landing page. I was not sure where exactly we wanted it, so I added it below the "browse topics section" the landing page is now structured like so:

* TensorSpace splash gif
* About Us
* Browse Topics
* **Search Docs**
* Popular Articles
* Video Content
* Didn't find an answer? Contact us.

I expect that we may want to move this around. Let me know your thoughts.