### PR TITLE
Possible fix: Updated KaTex stylesheet to point to CDN instead of locally

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,10 +7,8 @@
   <link rel="stylesheet" href="{{ "/uploads/css/main.css" | relative_url }}">
   <link rel="shortcut icon" type="image/png" href="{{ "/uploads/favicon.png" | relative_url }}" >
   <link rel="alternate" type="application/rss+xml" title="{{ site.title | escape }}" href="{{ "/feed.xml" | relative_url }}">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">  
   <script src="{{ "/uploads/js/main.js" | relative_url }}"></script>
-  <!-- KaTex.js -->
-  <link rel="stylesheet" href="/uploads/lib/katex/katex.min.css">
-  
   {% if page.hero.search or site.navbar.search %}
   {% include search-js.html %}
   {% endif %}


### PR DESCRIPTION
I noticed the stylesheet for KaTex was giving a 404 error in production.

This should prevent that error. Let's see if it fixes KaTex for production.