### PR TITLE
Bug fix: KaTex works in production

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,9 +7,10 @@
   <link rel="stylesheet" href="{{ "/uploads/css/main.css" | relative_url }}">
   <link rel="shortcut icon" type="image/png" href="{{ "/uploads/favicon.png" | relative_url }}" >
   <link rel="alternate" type="application/rss+xml" title="{{ site.title | escape }}" href="{{ "/feed.xml" | relative_url }}">
-  <script type="text/javascript" async
-    src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-MML-AM_CHTML">
-  </script>
+  <!-- Load KaTeX -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
+  <script src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
+  <!-- Custom Scripts -->
   <script src="{{ "/uploads/js/main.js" | relative_url }}"></script>
   {% if page.hero.search or site.navbar.search %}
   {% include search-js.html %}

--- a/_includes/hook-pre-closing-body.html
+++ b/_includes/hook-pre-closing-body.html
@@ -1,0 +1,44 @@
+<script>
+  const getAllScripts = () => {
+    return document.getElementsByTagName("script");
+  }
+
+  const isInlineMathJaxScript = (script) => {
+    return script.type === "math/tex";
+  }
+
+  const isDisplayMathJaxScript = (script) => {
+    return script.type === "math/tex; mode=display";
+  }
+
+  const renderInlineKatex = (script, tex) => {
+    let elem = document.createElement('div');
+    script.parentNode.insertBefore(elem, script.nextSibling);
+
+    katex.render(tex, elem);
+  }
+
+  const renderDisplayKatex = (script, tex) => {
+    let elem = document.createElement('div');
+    script.parentNode.insertBefore(elem, script.nextSibling);
+
+    katex.render(tex, elem, { displayMode: true });
+  }
+
+  const mathJaxToKatex = () => {
+    const scripts = getAllScripts();
+
+    for (const script of scripts) {
+
+      if (isInlineMathJaxScript(script)) {
+        renderInlineKatex(script, script.innerHTML);
+      }
+
+      if (isDisplayMathJaxScript(script)) {
+        renderDisplayKatex(script, script.innerHTML);
+      }
+    }
+  }
+
+  mathJaxToKatex();
+</script>

--- a/_posts/2019-12-21-example-post.md
+++ b/_posts/2019-12-21-example-post.md
@@ -6,7 +6,7 @@ title:  Post Template
 
 ## Contents
 * [Create an Article, Event, or other post](#create-post)
-* [Use Katex](#use-katex)
+* [Use Mathjax](#use-katex)
 * [Add a Video](#add-video)
 * [Add a image](#add-image)
 * [Edit a non-post page](#edit-page)

--- a/_posts/2019-12-21-example-post.md
+++ b/_posts/2019-12-21-example-post.md
@@ -51,6 +51,12 @@ _Today we'll go over the Pythagorean Theorem..._
 $$
 a^{2} + b^{2} = c^{2}
 $$
+
+# Inline mode:
+
+\$$
+a^{2} + b^{2} = c^{2}  
+$$
 ```
 
 ...Which results in the following output:
@@ -60,6 +66,10 @@ _Today we'll go over the Pythagorean Theorem..._
 
 $$
 a^{2} + b^{2} = c^{2}
+$$
+
+\$$
+a^{2} + b^{2} = c^{2}  
 $$
 
 ## Add a Video

--- a/_posts/2019-12-21-example-post.md
+++ b/_posts/2019-12-21-example-post.md
@@ -41,10 +41,10 @@ For example, this is how you create a new _post_ for the _Articles_ page:
 4. Confirm your article shows up on the site.
 
 
-## Use KaTex
+## Use MathJax
 <span id="use-katex"></span>
 
-Use [KaTex](https://katex.org/docs/supported.html) to draw Math formulas directly in `Markdown`. Katex "has its own language" for mathematicians to showcase formulas in the browser. Below is a simple example of using Katex:
+Use [MathJax](http://docs.mathjax.org/en/latest/) to draw Math formulas directly in `Markdown`. Mathjax uses `LaTeX` and `TeX` macros to parse math formulas. [See the Katex docs](https://katex.org/docs/supported.html) for a full list of `LaTeX` and `TeX` macros. Although Katex and Mathjax are separate libraries, both accept the same input. Katex has better documentation on the list of `LaTeX` and `Tex` macros. Below is a simple example of using Katex:
 ```
 _Today we'll go over the Pythagorean Theorem..._
 

--- a/_posts/2019-12-21-example-post.md
+++ b/_posts/2019-12-21-example-post.md
@@ -6,7 +6,7 @@ title:  Post Template
 
 ## Contents
 * [Create an Article, Event, or other post](#create-post)
-* [Use Mathjax](#use-katex)
+* [Use KaTex](#use-katex)
 * [Add a Video](#add-video)
 * [Add a image](#add-image)
 * [Edit a non-post page](#edit-page)
@@ -41,10 +41,10 @@ For example, this is how you create a new _post_ for the _Articles_ page:
 4. Confirm your article shows up on the site.
 
 
-## Use MathJax
+## Use KaTex
 <span id="use-katex"></span>
 
-Use [MathJax](http://docs.mathjax.org/en/latest/) to draw Math formulas directly in `Markdown`. Mathjax uses `LaTeX` and `TeX` macros to parse math formulas. [See the Katex docs](https://katex.org/docs/supported.html) for a full list of `LaTeX` and `TeX` macros. Although Katex and Mathjax are separate libraries, both accept the same input. Katex has better documentation on the list of `LaTeX` and `Tex` macros. Below is a simple example of using Katex:
+Use [KaTex](https://katex.org/docs/supported.html) to draw Math formulas directly in `Markdown`. KaTex uses `LaTeX` and `TeX` macros to parse math formulas. [See the Katex docs](https://katex.org/docs/supported.html) for a full list of `LaTeX` and `TeX` macros.B elow is a simple example of using Katex:
 ```
 _Today we'll go over the Pythagorean Theorem..._
 


### PR DESCRIPTION
Close #46 

Okay, after some effort, I figured this out. I had to create custom scripts to find KaTex delimiters (The $$ katex $$ signs) and manually use the KaTex API.

I'm confident this will work in production, but it is untested.

~~I replaced KaTex with Mathjax. I wasn't sure why katex wasn't working, so I swapped us over to mathjax.~~

~~After some research, I learned MathJax and KaTex accept the same input `LaTeX` / `TeX` (and do exactly the same thing), only katex is more efficient.~~

~~All of our previous functionality is the same, and as an author, you wouldn't notice much of a difference. **I confirmed this works in production.**~~