### PR TITLE
Issue-51: Fix video embeds

### DIFF
--- a/_events/2020-02-04-Maglione.md
+++ b/_events/2020-02-04-Maglione.md
@@ -18,12 +18,11 @@ Joshua Maglione
 
 **Speaker:** <a href="https://www.math.uni-bielefeld.de/~jmaglione/" target="_blank">Josh Maglione</a>, U. Bielefeld
 
- {% 
-    include video.html
-    src="https://sms.cam.ac.uk/media/3155105/embed"
-    title="Isomorphism, derivations, and Lie representations"
-    desc="For more visit https://TheTensor.Space/. Creative Commons 2.0 CC-ND 2020 Joshua Maglione."
-  %}
-
+{% 
+  include video.html
+  src="https://sms.cam.ac.uk/media/3155105/embed"
+  title="Isomorphism, derivations, and Lie representations"
+  desc="For more visit https://TheTensor.Space/. Creative Commons 2.0 CC-ND 2020 Joshua Maglione."
+%}
 
 <br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/4.0/" target="_blank">Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License</a>.

--- a/_includes/iframe.html
+++ b/_includes/iframe.html
@@ -1,0 +1,3 @@
+<div class="iframe-wrapper">
+  <iframe class="iframe" src="{{ include.src }}" scrolling="no"></iframe>
+</div>

--- a/_posts/2019-12-21-example-post.md
+++ b/_posts/2019-12-21-example-post.md
@@ -110,6 +110,30 @@ Sometimes you get into trouble mixing languages.  For example markdown likes to 
   desc="Introduction to Tensors, Tensor Spaces, and Transverse Operators. Creative Commons 2.0 CC-BY 2019 James B. Wilson"
 %}
 
+### Direct Embed
+Directly embedding a video can avoid issues caused by the theme and / or video provider.
+
+To directly embed a video, it's recommended to follow these instructions:
+
+1. Get the a video's **embed** `src` (often, clicking "share", then "embed" or "iframe" will lead you here).
+2. Use the following component:
+
+```
+{%
+  include iframe.html
+  src="https://sms.cam.ac.uk/media/3155105/embed"
+%}
+```
+
+...to render this output:
+
+{%
+  include iframe.html
+  src="https://sms.cam.ac.uk/media/3155105/embed"
+%}
+
+You can also copy and paste an `iframe` directly onto a page, but using this component will make the iframe fit to the page nicely.
+
 ## Add an image
 <span id="add-image"></span>
 

--- a/_sass/my-custom/_iframe.scss
+++ b/_sass/my-custom/_iframe.scss
@@ -1,0 +1,18 @@
+.iframe-wrapper {
+  position: relative;
+  overflow: hidden;
+  // Keep a 9 x 16 ratio
+  padding-top: 56.25%;
+  margin: 20px 0;
+}
+
+.iframe {
+  z-index: 5;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  overflow: hidden !important;
+}

--- a/_sass/uikit/components/_import.scss
+++ b/_sass/uikit/components/_import.scss
@@ -89,3 +89,6 @@
 
 // Need to be loaded last
 @import "print.scss";
+
+// Custom
+@import "../../my-custom/iframe";

--- a/uploads/css/main.scss
+++ b/uploads/css/main.scss
@@ -28,3 +28,4 @@
 @import "my-custom/navbar-logo";
 @import "my-custom/landing-page";
 @import "my-custom/post-sidebar";
+@import "my-custom/iframe";


### PR DESCRIPTION
Close #51 

After some digging, it looks like the theme doesn't support certain videos (not sure why). The solution I came up with was to create a new custom component to _directly embed_ videos on a page like so:

![Untitled](https://user-images.githubusercontent.com/28692645/74089596-05a16300-4a60-11ea-94a8-07da0be7b521.png)

This gives you the **option** to directly embed videos rather than using the theme's video.html component.

I **added instructions** on how to do this in the post template.

@algeboy does this solution work for you?


