### PR TITLE
More latex fixes and findings

### DIFF
--- a/_docs/tensorCategories.md
+++ b/_docs/tensorCategories.md
@@ -17,6 +17,7 @@ $$
 \langle \cdot |:S\to U_0\oslash U_1.
 $$
 Observe that intential separation of $V_0$ from $V_1$ we should seek morphisms between $V_0$ and $U_0$, and separately $V_1$ and $U_1$.  But this is still ambiguous.  There are at least 4 natural choices.
+
 $$
 \begin{matrix}
 V_1 & \overset{t}{\to} & V_0\\
@@ -26,6 +27,7 @@ U_1 & \overset{s}{\to} & U_0
 \qquad
 \langle s|f_1 v_1\rangle=f_0\langle t|v_1\rangle
 $$
+
 $$
 \begin{matrix}
 V_1 & \overset{t}{\to} & V_0\\
@@ -35,6 +37,7 @@ U_1 & \overset{s}{\to} & U_0
 \qquad
 \langle s|u_1\rangle=f_0\langle t|f^1 u_1\rangle
 $$
+
 $$
 \begin{matrix}
 V_1 & \overset{t}{\to} & V_0\\
@@ -44,6 +47,7 @@ U_1 & \overset{s}{\to} & U_0
 \qquad
 f^0\langle s|f_1v_1\rangle=\langle t|v_1\rangle
 $$
+
 $$
 \begin{matrix}
 V_1 & \overset{t}{\to} & V_0\\

--- a/_docs/tensorSpaces.md
+++ b/_docs/tensorSpaces.md
@@ -10,13 +10,11 @@ author: james
 
 
 The context is that we have a fixed commutative ring $K$ of coefficients, often a field or the integers.  We also have $K$-modules $V_0,\ldots,V_{\ell}$.  We define the space of multilinear maps recursively
-$$
-\begin{aligned}
-V_0\oslash V_1 & = \hom_K(V_1,V_0)=\{\langle f|:V_1\to V_0\textnormal{ linear}\}\\
+\begin{align\*}
+V_0\oslash V_1 & = \hom_K(V_1,V_0)=\{\langle f|:V_1\to V_0\textnormal{ linear}\} \\\\ 
 V_0\oslash \cdots \oslash V_{\ell} & = (V_0\oslash\cdots \oslash V_{\ell-1})\oslash V_{\ell}
-\end{aligned}
-$$
-See [Tensors](Tensors) for a detailed walk through this notation and definitions.
+\end{align\*}
+See [Tensors](/docs/tensors) for a detailed walk through this notation and definitions.
 
 We can now define a tensor space.  
 

--- a/_docs/tensors.md
+++ b/_docs/tensors.md
@@ -103,24 +103,22 @@ $$
 
 
 Indeed,
-$$
-\begin{aligned}
+\begin{align\*}
 \langle f|\alpha u_2+\beta u_2', u_1\rangle
-& = \alpha\langle f|u_2,u_1\rangle+\beta\langle f|u_2',u_1\rangle\\
+& = \alpha\langle f|u_2,u_1\rangle+\beta\langle f|u_2',u_1\rangle\\\\ 
 \langle f|u_2, \alpha u_1+\beta u_1'\rangle
 & = \alpha\langle f|u_2,u_1\rangle+\beta\langle f|u_2,u'_1\rangle
-\end{aligned}
-$$
+\end{align\*}
+
 A lot of fuss is made about the scalars but in truth once we know $\langle f|$ is bilinear we can reconstruct the scalars for free through something called _centroids_.  Trust us.  So really you can ignore $\alpha$'s and $\beta$'s and focus on one key point:
 > Bilinear maps are distributive products.
 
-To drive that point home write $u_2*u_1 := \langle f|u_2,u_1\rangle$ and let $\alpha=\beta=1$.  Then all we have said is the following.
-$$
-\begin{aligned}
-(u_2+u'_2)*u_1 & =  u_2*u_1 + u'_2*u_1\\
-u_2*(u_1+u'_1) & =  u_2*u_1 + u_2*u'_1
-\end{aligned}
-$$
+To drive that point home write $u_2*u_1 := \langle f \mid u_2,u_1\rangle$ and let $\alpha=\beta=1$.  Then all we have said is the following.
+
+\begin{align\*}
+(u_2+u'_2)\*u_1 & =  u_2\*u_1 + u'_2\*u_1\\\\ 
+u_2\*(u_1+u'_1) & =  u_2\*u_1 + u_2\*u'_1
+\end{align\*}
 
 ### Multilinear maps
 
@@ -134,6 +132,7 @@ V_0\oslash \cdots \oslash V_{\ell+1} :=
 (V_0\oslash \cdots\oslash V_{\ell})\oslash V_{\ell+1}
 $$
 consists of _multi_-linear maps.  Once more the scalars are barely important.  You should think of these are large distributive products.  Something like trinomials $xyz$, i.e.
+
 $$
 \begin{aligned}
 (x+x')yz & = xyz+x'yz \\
@@ -141,7 +140,9 @@ x(y+y')z & = xyz+xy'z\\
 xy(z+z') & = xyz+xyz'.
 \end{aligned}
 $$
-Our Dirac styled notation lets us capture these higher arity products.  Here we have a trinary distributive product $\langle t|$:
+
+Our Dirac styled notation lets us capture these higher arity products.  Here we have a trinary distributive product $\langle t\|$:
+
 $$
 \begin{aligned}
 \langle t| v_3+v'_3,v_2,v_1\rangle & = \langle t | v_3,v_2,v_1\rangle+\langle t|v'_3,v_2,v_1\rangle \\
@@ -149,9 +150,10 @@ $$
 \langle t| v_3,v_2,v_1+v'_1\rangle & = \langle t | v_3,v_2,v_1\rangle+\langle t|v_3,v_2,v'_1\rangle.
 \end{aligned}
 $$
+
 There is a little notational manuever to cut down on repetition.  Since we bothered to index our variables, there is no need to put them in order.  So distributive in all variables can be captured with one identity.
 $$
-(\forall a)\qquad
+(\forall a)\quad
 \langle t|v_a+v'_a,v_{\bar{a}}\rangle=\langle t|v_a,v_{\bar{a}}\rangle+\langle t|v'_a,v_{\bar{a}}\rangle.
 $$
 Her $\bar{a}$ means the complement of the index $a$ in $\{1,\ldots,\ell\}$.

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -26,7 +26,9 @@
                   {left: '\\[', right: '\\]', display: true},
                   {left: "\\begin{equation}", right: "\\end{equation}", display: true},
                   {left: '\\begin{align}', right: '\\end{align}', display: true},
+                  {left: '\\begin{align*}', right: '\\end{align*}', display: true},
                   {left: '\\begin{gather}', right: '\\end{gather}', display: true},
+                  {left: '\\begin{gather*}', right: '\\end{gather*}', display: true},
               ],
               // • rendering keys, e.g.:
               throwOnError : false

--- a/_posts/2020-01-02-What-Is-A-Tensor.md
+++ b/_posts/2020-01-02-What-Is-A-Tensor.md
@@ -97,6 +97,7 @@ $$
 
 
 Indeed,
+
 $$
 \begin{aligned}
 \langle f|\alpha u_2+\beta u_2', u_1\rangle
@@ -105,10 +106,12 @@ $$
 & = \alpha\langle f|u_2,u_1\rangle+\beta\langle f|u_2,u'_1\rangle
 \end{aligned}
 $$
+
 A lot of fuss is made about the scalars but in truth once we know $\langle f|$ is bilinear we can reconstruct the scalars for free through something called _centroids_.  Trust us.  So really you can ignore $\alpha$'s and $\beta$'s and focus on one key point:
 > Bilinear maps are distributive products.
 
-To drive that point home write $u_2*u_1 := \langle f|u_2,u_1\rangle$ and let $\alpha=\beta=1$.  Then all we have said is the following.
+To drive that point home write $u_2*u_1 := \langle f\|u_2,u_1\rangle$ and let $\alpha=\beta=1$.  Then all we have said is the following.
+
 $$
 \begin{aligned}
 (u_2+u'_2)*u_1 & =  u_2*u_1 + u'_2*u_1\\
@@ -128,6 +131,7 @@ V_0\oslash \cdots \oslash V_{\ell+1} :=
 (V_0\oslash \cdots\oslash V_{\ell})\oslash V_{\ell+1}
 $$
 consists of _multi_-linear maps.  Once more the scalars are barely important.  You should think of these are large distributive products.  Something like trinomials $xyz$, i.e.
+
 $$
 \begin{aligned}
 (x+x')yz & = xyz+x'yz \\
@@ -135,7 +139,9 @@ x(y+y')z & = xyz+xy'z\\
 xy(z+z') & = xyz+xyz'.
 \end{aligned}
 $$
-Our Dirac styled notation lets us capture these higher arity products.  Here we have a trinary distributive product $\langle t|$:
+
+Our Dirac styled notation lets us capture these higher arity products.  Here we have a trinary distributive product $\langle t\|$:
+
 $$
 \begin{aligned}
 \langle t| v_3+v'_3,v_2,v_1\rangle & = \langle t | v_3,v_2,v_1\rangle+\langle t|v'_3,v_2,v_1\rangle \\
@@ -143,9 +149,10 @@ $$
 \langle t| v_3,v_2,v_1+v'_1\rangle & = \langle t | v_3,v_2,v_1\rangle+\langle t|v_3,v_2,v'_1\rangle.
 \end{aligned}
 $$
+
 There is a little notational manuever to cut down on repetition.  Since we bothered to index our variables, there is no need to put them in order.  So distributive in all variables can be captured with one identity.
 $$
-(\forall a)\qquad
+(\forall a)\quad
 \langle t|v_a+v'_a,v_{\bar{a}}\rangle=\langle t|v_a,v_{\bar{a}}\rangle+\langle t|v'_a,v_{\bar{a}}\rangle.
 $$
 Her $\bar{a}$ means the complement of the index $a$ in $\{1,\ldots,\ell\}$.

--- a/_posts/2020-02-07-Whitney-Tensor.md
+++ b/_posts/2020-02-07-Whitney-Tensor.md
@@ -24,20 +24,20 @@ If you never understood a tensor product this article is for you.  If you alread
 
 ### The tensor product with coordinates
 
-Let \\(\mathbb{R}\\) be the coefficients of our tensor -- if you know of other commutative rings use whatever you like here. Let us assume \\(\mathbb{R}^a\\) is a list (a row) vector and\\(v^{\top}\\) denote a transpose.
+Let \\(\mathbb{R}\\) be the coefficients of our tensor -- if you know of other commutative rings use whatever you like here. Let us assume \\(\mathbb{R}^a\\) is a list (a row) vector and \\(v^{\top}\\) denote a transpose.
 
-\begin{gather}
+\begin{gather\*}
     \otimes:\mathbb{R}^a\times \mathbb{R}^b\rightarrowtail 
         \mathbb{M}_{a\times b}(\mathbb{R})
     \qquad
     v\otimes u := v^{\top}u.
-\end{gather}
+\end{gather\*}
 
 ![](/uploads/images/Tensor-Product-Def-2D.gif)
 
 For example with $v=(1,7)$ and $u=(1,2,3)$ we get
 
-\begin{gather}
+\begin{gather\*}
 v\otimes u =
 \begin{bmatrix}
 % IMPORTANT 1: need the space after the 4 backslashes. otherwise will not render.
@@ -55,7 +55,7 @@ v\otimes u =
 1 & 2 & 3\\\\ 
 7 & 14 & 21
 \end{bmatrix}.
-\end{gather}
+\end{gather\*}
 
 What is\\(\rightarrowtail\\)?  It special notation for the distributive property.
 
@@ -94,7 +94,7 @@ Proof. Let \\(\{e_1,\ldots,e_a\}\\) be a basis of \\(\mathbb{R}^a\\) and \\(\{f_
 
 Here \\(E_{ij}\\) is the \\((a\times b)\\)-matrix with zero every except at \\(ij\\) where it is \\(1\\).  Evidently \\(\{E_{ij}\}\\) is a basis of \\(\mathbb{M}_{a\times b}(\mathbb{R})\\) so we have defined \\(\hat{\circ}\\) on a basis. \\(\Box\\)
 
-**Remark.** For those in the know: we haven't avoided free modules. We still use a basis, but we haven't needed to add in additional relations such as \\((v_2+v'_2,v_1)-(v_2,v_1)-(v'_2,v_1)\\) and others in order to create \\(V_2\otimes V_1\\).  Matrices already include the necessary relations.  If it seems this is a trick solely possible for fields then take a look at our later section.
+**Remark.** For those in the know: we haven't avoided free modules. We still use a basis, but we haven't needed to add in additional relations such as \\((v_2+v\'_2,v_1)-(v_2,v_1)-(v\'_2,v_1)\\) and others in order to create \\(V_2\otimes V_1\\).  Matrices already include the necessary relations.  If it seems this is a trick solely possible for fields then take a look at our later section.
 
 **Observation 2.** 
 
@@ -127,10 +127,10 @@ That is it.  We have made a tensor product of two vector spaces.  Some call this
 
 This was almost too easy.  Why don't we try something a bit harder.  For example lets assume an audience now that knows of quotients, for example \\(\mathbb{Z}/12=\{0,1,2,\ldots,11\}\\), i.e.: the time of day which is cyclical and resets every 12 hours, and letting \\(0\\) be \\(12\\). The let us make more creative lists of vectors (modules technically).
 
-\begin{align}
+\begin{align\*}
 V_2 & = \mathbb{Z}/3\oplus\mathbb{Z}/6\\\\ 
 V_1 & = \mathbb{Z}/2\oplus \mathbb{Z}/6\oplus \mathbb{Z}/12
-\end{align}
+\end{align\*}
 
 How should we form \\(V_2\otimes V_1\\)?  Again matrices suffice, but we have to fold in the concept of an **ideal**.
 
@@ -152,18 +152,18 @@ Vertically we take the tensor product of the \\(\mathbb{Z}\\)'s creating
 
 This is a distributive product, and to make quotients of distributive products we need ideals.  Ideals are subspaces that absorb products on the right, such as
 
-\begin{align}
+\begin{align\*}
 R & := \\{(3a,6b)\mid a,b\in \mathbb{Z}\\}\otimes \mathbb{Z}^{\oplus 3}\\\\ 
 & = \left\\{
     \begin{bmatrix} 3a & 3b & 3c \\\\ 
     6d & 6e & 6f
     \end{bmatrix} \middle| a,b,c,d,e,f\in \mathbb{Z}\right
     \\}
-\end{align}
+\end{align\*}
 
 left ideals absorb products on the left
 
-\begin{align}
+\begin{align\*}
 L & := \mathbb{Z}^{\oplus 2}\otimes \{(2a,6b,12c)\mid a,b,c\in \mathbb{Z}\}\\\\ 
 & = \left\\{
     \begin{bmatrix}
@@ -171,38 +171,38 @@ L & := \mathbb{Z}^{\oplus 2}\otimes \{(2a,6b,12c)\mid a,b,c\in \mathbb{Z}\}\\\\
     2d & 6e & 12 f
     \end{bmatrix}\middle| a,b,c,d,e,f\in \mathbb{Z}\right
     \\}
-\end{align}
+\end{align\*}
 
 So to make 2-sided ideal we add these together:
 
-\begin{align}
+\begin{align\*}
 I := R+L = \left\\{
     \begin{bmatrix}
     1a & 3b & 3c\\\\ 
     2d & 6e & 6f
     \end{bmatrix}\middle| a,b,c,d,e,f\in \mathbb{Z}\right
     \\}
-\end{align}
+\end{align\*}
 
 **Definition.**
 
-\begin{align}
+\begin{align\*}
 V_2\otimes V_1 = \mathbb{M}_{2\times 3}(\mathbb{Z})/I  \\\\ 
 \begin{bmatrix}
 \mathbb{Z}/1 & \mathbb{Z}/3 & \mathbb{Z}/3 \\\\ 
 \mathbb{Z}/2 & \mathbb{Z}/6 & \mathbb{Z}/6
 \end{bmatrix}
-\end{align}
+\end{align\*}
 
 
 Some may wish to check this against other treatments.
 
 
-\begin{align}
+\begin{align\*}
 (\mathbb{Z}/3\oplus \mathbb{Z}/6)&\otimes (\mathbb{Z}/2\oplus \mathbb{Z}/6\oplus \mathbb{Z}/12) \\\\ 
 & =(\mathbb{Z}/3\otimes (\mathbb{Z}/2\oplus \mathbb{Z}/6\oplus \mathbb{Z}/12))\oplus (\mathbb{Z}/6\otimes (\mathbb{Z}/2\oplus \mathbb{Z}/6\oplus \mathbb{Z}/12)) \\\\ 
 & =(\mathbb{Z}/1\oplus \mathbb{Z}/3\oplus \mathbb{Z}/3)\oplus (\mathbb{Z}/2\oplus \mathbb{Z}/6\oplus \mathbb{Z}/6).
-\end{align}
+\end{align\*}
 
 For those who know what to expect, we get what we expect.  And again we
 have not had to begin with the free module \\(\mathbb{Z}[V_2\times V_1]\\) and throw in an enormous number of relations.  In fact the matrix model we have used is an ideal choice for computation.


### PR DESCRIPTION
An align environment with no equation numbering can either be done in Markdown with
```
\begin{align\*}
...
\end{align\*}
```
(need to escape the `*`, and escape characters in the environment)

or

```
$$
\begin{aligned}
...
\end{aligned}
$$
```
(no need to escape markdown characters in the environment, there's something in the markdown parser avoiding the escape in this case, but the start of `$$` should be on a newline, or the display mode math is inlined in a strange way.)

I fixed some existing small oddities on a few pages.